### PR TITLE
Fixes "SyntaxError: Unexpected end of JSON input" error. (Migrate xkcd module to use https)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-var http = require('http');
+var https = require('https');
 
-var DOMAIN = 'http://xkcd.com/';
+var DOMAIN = 'https://xkcd.com/';
 var PATH = 'info.0.json';
 
 // Gets the current xkcd.
@@ -11,7 +11,7 @@ function current (id, cb) {
   var idURL = id ? id + '/' : '';
   var url = DOMAIN + idURL + PATH;
 
-  http.get(url, function(res) {
+  https.get(url, function(res) {
     var body = '';
 
     res.on('data', function(chunk) {
@@ -43,5 +43,7 @@ var xkcd = function () {
     current(undefined, cb);
   }
 };
+
+xkcd((data) => console.log(data));
 
 module.exports = xkcd;

--- a/index.js
+++ b/index.js
@@ -44,6 +44,4 @@ var xkcd = function () {
   }
 };
 
-xkcd((data) => console.log(data));
-
 module.exports = xkcd;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xkcd",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A simple xkcd API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This commit updates the xkcd module to use https. This change is
necessary due to requests to xkcd over http being redirected with a 301
status code. This caused the xkcd module to break giving an error message like this:

```
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at IncomingMessage.<anonymous> (/home/kevin/source/xkcd/index.js:22:23)
    at emitNone (events.js:91:20)
    at IncomingMessage.emit (events.js:185:7)
    at endReadableNT (_stream_readable.js:974:12)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```
This problem was resolved by migrating the xkcd module to consume the
XKCD API over https.